### PR TITLE
add option to disable shared formula tracking

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/StreamingReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/StreamingReader.java
@@ -47,6 +47,7 @@ public class StreamingReader implements AutoCloseable {
     private boolean readCoreProperties = false;
     private boolean readHyperlinks = false;
     private boolean readShapes = false;
+    private boolean readSharedFormulas = true;
     private boolean fullFormatRichText = false;
     private String password;
 
@@ -138,6 +139,14 @@ public class StreamingReader implements AutoCloseable {
      */
     public boolean readShapes() {
       return readShapes;
+    }
+
+    /**
+     * @return Whether to read the shared formulas. Only affects cell formulas, cell values are retrieved
+     * using values stored in the sheet data.
+     */
+    public boolean readSharedFormulas() {
+      return readSharedFormulas;
     }
 
     /**
@@ -340,6 +349,18 @@ public class StreamingReader implements AutoCloseable {
      */
     public Builder setReadShapes(boolean readShapes) {
       this.readShapes = readShapes;
+      return this;
+    }
+
+    /**
+     * Enables the reading of shared formulas. This is enabled by default.
+     * Only affects cell formulas, cell values are retrieved using values stored in the sheet data.
+     *
+     * @param readSharedFormulas whether to read shared formulas
+     * @return reference to current {@code Builder}
+     */
+    public Builder setReadSharedFormulas(boolean readSharedFormulas) {
+      this.readSharedFormulas = readSharedFormulas;
       return this;
     }
 

--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingCell.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingCell.java
@@ -291,7 +291,7 @@ public class StreamingCell implements Cell {
     if (!formulaType)
       throw new IllegalStateException("This cell does not have a formula");
     if ((formula == null || formula.isEmpty()) && sharedFormula)
-      throw new IllegalStateException("This cell has a shared formula and excel-streaming-reader does not support this yet");
+      throw new IllegalStateException("This cell has a shared formula and it seems setReadSharedFormulas has been set to false");
     return formula;
   }
 

--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheetReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheetReader.java
@@ -93,17 +93,23 @@ public class StreamingSheetReader implements Iterable<Row> {
   }
 
   Map<String, SharedFormula> getSharedFormulaMap() {
-    if (sharedFormulaMap == null) {
-      return Collections.emptyMap();
+    if (getBuilder().readSharedFormulas()) {
+      if (sharedFormulaMap == null) {
+        return Collections.emptyMap();
+      }
+      return Collections.unmodifiableMap(sharedFormulaMap);
+    } else {
+      throw new IllegalStateException("The reading of shared formulas has been disabled. Enable using StreamingReader.Builder.");
     }
-    return Collections.unmodifiableMap(sharedFormulaMap);
   }
 
   void addSharedFormula(String siValue, SharedFormula sharedFormula) {
-    if (sharedFormulaMap == null) {
-      sharedFormulaMap = new HashMap<>();
+    if (getBuilder().readSharedFormulas()) {
+      if (sharedFormulaMap == null) {
+        sharedFormulaMap = new HashMap<>();
+      }
+      sharedFormulaMap.put(siValue, sharedFormula);
     }
-    sharedFormulaMap.put(siValue, sharedFormula);
   }
 
   SharedFormula removeSharedFormula(String siValue) {
@@ -338,7 +344,7 @@ public class StreamingSheetReader implements Iterable<Row> {
         if (currentCell != null) {
           final String formula = formulaBuilder.toString();
           currentCell.setFormula(formula);
-          if (currentCell.isSharedFormula() && currentCell.getFormulaSI() != null) {
+          if (currentCell.isSharedFormula() && currentCell.getFormulaSI() != null && getBuilder().readSharedFormulas()) {
             if (sharedFormulaMap == null) {
               sharedFormulaMap = new HashMap<>();
             }
@@ -377,7 +383,6 @@ public class StreamingSheetReader implements Iterable<Row> {
           }
         }
       }
-
     }
   }
 

--- a/src/test/java/com/github/pjfanning/xlsx/StreamingReaderTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/StreamingReaderTest.java
@@ -1216,6 +1216,42 @@ public class StreamingReaderTest {
     }
   }
 
+  @Test
+  public void testReadSharedFormulasDisabled() throws Exception {
+    try (
+            InputStream inputStream = new FileInputStream("src/test/resources/bug65464.xlsx");
+            Workbook wb = StreamingReader.builder()
+                    .setReadSharedFormulas(false)
+                    .open(inputStream)
+    ) {
+      Sheet sheet = wb.getSheet("SheetWithSharedFormula");
+      Cell v15 = null;
+      Cell v16 = null;
+      Cell v17 = null;
+      for (Row row : sheet) {
+        if (row.getRowNum() == 14) {
+          v15 = row.getCell(21);
+        } else if (row.getRowNum() == 15) {
+          v16 = row.getCell(21);
+        } else if (row.getRowNum() == 16) {
+          v17 = row.getCell(21);
+        }
+      }
+      assertNotNull("v15 found", v15);
+      assertNotNull("v16 found", v16);
+      assertNotNull("v17 found", v17);
+      assertEquals("U15/R15", v15.getCellFormula());
+      assertEquals("U16/R16", v16.getCellFormula());
+      try {
+        v17.getCellFormula();
+        fail("expected V17 getCellFormula to fail because setReadSharedFormulas is set false");
+      } catch (IllegalStateException ise) {
+        //expected
+      }
+    }
+  }
+
+
   private void testReadComments(boolean tempFileEnabled, boolean encrypt,
                                 boolean fullFormat) throws Exception {
     try(


### PR DESCRIPTION
Only affects calls to Cell.getCellFormula and using this option to disable the feature will save a little bit of memory.