### PR TITLE
Allow multiple iterations tests

### DIFF
--- a/src/test/java/com/github/pjfanning/xlsx/StreamingReaderTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/StreamingReaderTest.java
@@ -1212,30 +1212,20 @@ public class StreamingReaderTest {
 
   @Test
   public void testIteratingRowsOnSheetTwice() throws Exception {
-    Map<String, SharedFormula> sharedFormulaMap = null;
     try (
             Workbook wb = StreamingReader.builder()
                     .setReadSharedFormulas(true)
                     .open(new File("src/test/resources/bug65464.xlsx"))
     ) {
-      Sheet sheet = wb.getSheet("SheetWithSharedFormula");
+      StreamingSheet sheet = (StreamingSheet) wb.getSheet("SheetWithSharedFormula");
       for (Row row : sheet) {
         //iterate through rows to ensure all state is loaded for the sheet
       }
-      sharedFormulaMap = ((StreamingSheet)sheet).getSharedFormulaMap();
-    }
-    assertEquals(1, sharedFormulaMap.size());
+      Map<String, SharedFormula> sharedFormulaMap = sheet.getSharedFormulaMap();
 
-    //the only way to do a 2nd pass on the row data is to create a new workbook and iterate over its sheet
-    try (
-            Workbook wb = StreamingReader.builder()
-                    .setReadSharedFormulas(true)
-                    .open(new File("src/test/resources/bug65464.xlsx"))
-    ) {
-      StreamingSheet sheet = (StreamingSheet)wb.getSheet("SheetWithSharedFormula");
-      sharedFormulaMap.entrySet().forEach( entry ->
-              sheet.addSharedFormula(entry.getKey(), entry.getValue())
-      );
+      assertEquals(1, sharedFormulaMap.size());
+
+      sharedFormulaMap.forEach(sheet::addSharedFormula);
       Cell v15 = null;
       Cell v16 = null;
       Cell v17 = null;

--- a/src/test/java/com/github/pjfanning/xlsx/StreamingSheetTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/StreamingSheetTest.java
@@ -148,6 +148,10 @@ public class StreamingSheetTest {
       assertEquals("https://en.wikipedia.org/wiki/Apache_POI#See_also", a4.getStringCellValue());
       assertEquals("#Sheet1", a7.getStringCellValue());
 
+      for (Row row : sheet) {
+        //iterate again to make sure we don't duplicate the hyperlink data
+      }
+
       List<? extends Hyperlink> hps = sheet.getHyperlinkList();
       assertEquals(4, hps.size());
 


### PR DESCRIPTION
Update tests for #109 

I tried to think of what other use cases haven't been covered by existing tests, and the only 2 changes I could think of were:
- `StreamingReaderTest#testIteratingRowsOnSheetTwice()`: Remove new workbook workaround
- `StreamingSheetTest#testHyperlinksEnabled()`: Test for duplicate hyperlink data

I could add unit tests for `StreamingRowIterator`, but I feel like everything has already been covered by existing tests.