### PR TITLE
Change error to warning

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingRowIterator.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingRowIterator.java
@@ -378,7 +378,7 @@ class StreamingRowIterator implements CloseableIterator<Row> {
                 }
               }
             } else {
-              LOG.error("No eval workbook found");
+              LOG.warn("No eval workbook found");
             }
           }
         }


### PR DESCRIPTION
Some Excel sheets are giving this error. Everything still works after that, since we don't really need the formula, but the error is triggering our alerts. 

The message is also a bit cryptic, I have no idea if I can do anything to fix it.