### PR TITLE
add ExcelRuntimeException

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/exceptions/CloseException.java
+++ b/src/main/java/com/github/pjfanning/xlsx/exceptions/CloseException.java
@@ -1,6 +1,6 @@
 package com.github.pjfanning.xlsx.exceptions;
 
-public class CloseException extends RuntimeException {
+public class CloseException extends ExcelRuntimeException {
 
   public CloseException() {
     super();

--- a/src/main/java/com/github/pjfanning/xlsx/exceptions/ExcelRuntimeException.java
+++ b/src/main/java/com/github/pjfanning/xlsx/exceptions/ExcelRuntimeException.java
@@ -1,0 +1,23 @@
+package com.github.pjfanning.xlsx.exceptions;
+
+/**
+ * A parent class for all the excel-streaming-reader specific Runtime Exceptions.
+ */
+public class ExcelRuntimeException extends RuntimeException {
+
+  protected ExcelRuntimeException() {
+    super();
+  }
+
+  protected ExcelRuntimeException(String msg) {
+    super(msg);
+  }
+
+  protected ExcelRuntimeException(Exception e) {
+    super(e);
+  }
+
+  protected ExcelRuntimeException(String msg, Exception e) {
+    super(msg, e);
+  }
+}

--- a/src/main/java/com/github/pjfanning/xlsx/exceptions/MissingSheetException.java
+++ b/src/main/java/com/github/pjfanning/xlsx/exceptions/MissingSheetException.java
@@ -1,6 +1,6 @@
 package com.github.pjfanning.xlsx.exceptions;
 
-public class MissingSheetException extends RuntimeException {
+public class MissingSheetException extends ExcelRuntimeException {
 
   public MissingSheetException() {
     super();

--- a/src/main/java/com/github/pjfanning/xlsx/exceptions/NotSupportedException.java
+++ b/src/main/java/com/github/pjfanning/xlsx/exceptions/NotSupportedException.java
@@ -1,6 +1,6 @@
 package com.github.pjfanning.xlsx.exceptions;
 
-public class NotSupportedException extends RuntimeException {
+public class NotSupportedException extends ExcelRuntimeException {
 
   public NotSupportedException() {
     super();

--- a/src/main/java/com/github/pjfanning/xlsx/exceptions/OpenException.java
+++ b/src/main/java/com/github/pjfanning/xlsx/exceptions/OpenException.java
@@ -1,6 +1,6 @@
 package com.github.pjfanning.xlsx.exceptions;
 
-public class OpenException extends RuntimeException {
+public class OpenException extends ExcelRuntimeException {
 
   public OpenException() {
     super();

--- a/src/main/java/com/github/pjfanning/xlsx/exceptions/ParseException.java
+++ b/src/main/java/com/github/pjfanning/xlsx/exceptions/ParseException.java
@@ -1,6 +1,6 @@
 package com.github.pjfanning.xlsx.exceptions;
 
-public class ParseException extends RuntimeException {
+public class ParseException extends ExcelRuntimeException {
 
   public ParseException() {
     super();

--- a/src/main/java/com/github/pjfanning/xlsx/exceptions/ReadException.java
+++ b/src/main/java/com/github/pjfanning/xlsx/exceptions/ReadException.java
@@ -1,6 +1,6 @@
 package com.github.pjfanning.xlsx.exceptions;
 
-public class ReadException extends RuntimeException {
+public class ReadException extends ExcelRuntimeException {
 
   public ReadException() {
     super();


### PR DESCRIPTION
The existing exception handling is largely based on RuntimeExceptions. I have #228 open but many methods can't throw checked exceptions because the POI interface that is being implemented doesn't include checked exceptions.