### PR TITLE
make poi-shared-strings optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sonarqube {
 }
 
 group = 'com.github.pjfanning'
-version = '4.4.1-SNAPSHOT'
+version = '5.0.0-SNAPSHOT'
 
 sourceCompatibility = 1.8
 
@@ -29,21 +29,23 @@ repositories {
 
 ext {
     poiVersion = '5.3.0'
+    poiSharedStringsVersion = '2.9.0'
     slf4jVersion = '2.0.13'
 }
 
 dependencies {
     api "org.apache.poi:poi:$poiVersion"
     api "org.apache.poi:poi-ooxml:$poiVersion"
-    implementation 'com.github.pjfanning:poi-shared-strings:2.9.0'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation 'commons-io:commons-io:2.16.1'
     implementation 'org.apache.commons:commons-compress:1.26.2'
+    compileOnly "com.github.pjfanning:poi-shared-strings:$poiSharedStringsVersion"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.nanohttpd:nanohttpd:2.3.1'
     testImplementation 'org.mockito:mockito-core:4.11.0'
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     testRuntimeOnly 'org.apache.logging.log4j:log4j-to-slf4j:2.23.1'
+    testRuntimeOnly "com.github.pjfanning:poi-shared-strings:$poiSharedStringsVersion"
 }
 
 test {


### PR DESCRIPTION
* poi-shared-strings is only needed if you enable certain excel-streaming-reader features
* poi-shared-strings depends on h2 database jar (for MVStore) but h2 has some CVEs that don't affect how we use h2 MVStore but still we get complaints about the CVE(s)