### PR TITLE
create PoiSharedStringsSupport

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/PoiSharedStringsSupport.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/PoiSharedStringsSupport.java
@@ -1,0 +1,66 @@
+package com.github.pjfanning.xlsx.impl;
+
+import com.github.pjfanning.poi.xssf.streaming.CommentsTableBase;
+import com.github.pjfanning.poi.xssf.streaming.MapBackedCommentsTable;
+import com.github.pjfanning.poi.xssf.streaming.MapBackedSharedStringsTable;
+import com.github.pjfanning.poi.xssf.streaming.TempFileCommentsTable;
+import com.github.pjfanning.poi.xssf.streaming.TempFileSharedStringsTable;
+import com.github.pjfanning.xlsx.StreamingReader;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.xssf.model.Comments;
+import org.apache.poi.xssf.model.SharedStringsTable;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Keeps code that relies on poi-shared-strings out of the main codebase.
+ */
+public final class PoiSharedStringsSupport {
+    public static Comments createTempFileCommentsTable(final StreamingReader.Builder builder) throws IOException {
+        return new TempFileCommentsTable(
+                builder.encryptCommentsTempFile(),
+                builder.fullFormatRichText());
+    }
+
+    public static Comments createMapBackedCommentsTable(final StreamingReader.Builder builder) {
+        return new MapBackedCommentsTable(builder.fullFormatRichText());
+    }
+
+    public static SharedStringsTable createTempFileSharedStringsTable(
+            final StreamingReader.Builder builder) throws IOException {
+        return new TempFileSharedStringsTable(
+                builder.encryptSstTempFile(),
+                builder.fullFormatRichText());
+    }
+
+    public static SharedStringsTable createTempFileSharedStringsTable(
+            final OPCPackage pkg, final StreamingReader.Builder builder) throws IOException {
+        return new TempFileSharedStringsTable(
+                pkg,
+                builder.encryptSstTempFile(),
+                builder.fullFormatRichText());
+    }
+
+    public static SharedStringsTable createMapBackedSharedStringsTable(
+            final StreamingReader.Builder builder) {
+        return new MapBackedSharedStringsTable(builder.fullFormatRichText());
+    }
+
+    public static SharedStringsTable createMapBackedSharedStringsTable(
+            final OPCPackage pkg, final StreamingReader.Builder builder) throws IOException {
+        return new MapBackedSharedStringsTable(
+                pkg,
+                builder.fullFormatRichText());
+    }
+
+    public static void readComments(final Comments comments, final InputStream inputStream) throws IOException {
+        if (comments instanceof CommentsTableBase) {
+            ((CommentsTableBase) comments).readFrom(inputStream);
+        }
+    }
+
+    private PoiSharedStringsSupport() {
+        // no-op
+    }
+}

--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingRowIterator.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingRowIterator.java
@@ -522,7 +522,7 @@ class StreamingRowIterator implements CloseableIterator<Row> {
       case "e":           //error type
         return new StringSupplier("ERROR:  " + lastContents);
       case "n":           //numeric type
-        if(currentCell.getNumericFormat() != null && lastContents.length() > 0) {
+        if(currentCell.getNumericFormat() != null && !lastContents.isEmpty()) {
           // the formatRawCellContents operation incurs a significant overhead on large sheets,
           // and we want to defer the execution of this method until the value is actually needed.
           // it is not needed in all cases..
@@ -538,7 +538,7 @@ class StreamingRowIterator implements CloseableIterator<Row> {
           return new StringSupplier(lastContents);
         }
       case "d":           //date type (Strict OOXML format)
-        if(currentCell.getNumericFormat() != null && lastContents.length() > 0) {
+        if(currentCell.getNumericFormat() != null && !lastContents.isEmpty()) {
           // the formatRawCellContents operation incurs a significant overhead on large sheets,
           // and we want to defer the execution of this method until the value is actually needed.
           // it is not needed in all cases..

--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
@@ -1,7 +1,5 @@
 package com.github.pjfanning.xlsx.impl;
 
-import com.github.pjfanning.poi.xssf.streaming.MapBackedSharedStringsTable;
-import com.github.pjfanning.poi.xssf.streaming.TempFileSharedStringsTable;
 import com.github.pjfanning.xlsx.SharedStringsImplementationType;
 import com.github.pjfanning.xlsx.StreamingReader.Builder;
 import com.github.pjfanning.xlsx.exceptions.ExcelRuntimeException;
@@ -186,9 +184,9 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, Date1904Support
 
     if (builder.getSharedStringsImplementationType() == SharedStringsImplementationType.TEMP_FILE_BACKED) {
       log.info("Created sst cache file");
-      sst = new TempFileSharedStringsTable(pkg, builder.encryptSstTempFile(), builder.fullFormatRichText());
+      sst = PoiSharedStringsSupport.createTempFileSharedStringsTable(pkg, builder);
     } else if (builder.getSharedStringsImplementationType() == SharedStringsImplementationType.CUSTOM_MAP_BACKED) {
-      sst = new MapBackedSharedStringsTable(pkg, builder.fullFormatRichText());
+      sst = PoiSharedStringsSupport.createMapBackedSharedStringsTable(pkg, builder);
     } else if (strictFormat) {
       sst = OoxmlStrictHelper.getSharedStringsTable(builder, pkg);
     } else {


### PR DESCRIPTION
v5.0.0 is broken - we have lots of classes that access poi-shared-strings code even when we don't enable the poi-shared-strings support.

This is not the final change needed. There is a bit more to do.