### PR TITLE
close OPC Package instance

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
@@ -345,6 +345,7 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, Date1904Support
         }
       }
       pkg.revert();
+      pkg.close();
     } finally {
       if(tmp != null) {
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
Close the OPC Package when the Workbook is closed. Currently, only revert is called.