### PR TITLE
Close sheets that were opened by getSheetAt/getSheet

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
@@ -331,14 +331,28 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, Date1904Support
     return use1904Dates;
   }
 
+  /**
+   * Closes every sheet that has been created so far. Sheets can be created either by
+   * {@link #getSheets()} (which populates <code>sheets</code>) or by {@link #getSheetAt(int)}/
+   * {@link #getSheet(String)} (which populate <code>sheetMap</code>), so both need to be closed.
+   */
+  private void closeSheets() {
+    // a Set is used because the same sheet can appear in both collections;
+    // StreamingSheet does not override equals/hashCode, so this dedupes on identity
+    final Set<StreamingSheet> openSheets = new LinkedHashSet<>();
+    if (sheets != null) {
+      openSheets.addAll(sheets);
+    }
+    openSheets.addAll(sheetMap.values());
+    for(StreamingSheet sheet : openSheets) {
+      sheet.getReader().close();
+    }
+  }
+
   @Override
   public void close() throws IOException {
     try {
-      if (sheets != null) {
-        for(StreamingSheet sheet : sheets) {
-          sheet.getReader().close();
-        }
-      }
+      closeSheets();
     } finally {
       try {
         pkg.revert();

--- a/src/test/java/com/github/pjfanning/xlsx/StreamingWorkbookTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/StreamingWorkbookTest.java
@@ -11,6 +11,7 @@ import org.apache.poi.openxml4j.opc.ZipPackage;
 import org.apache.poi.openxml4j.util.ZipInputStreamZipEntrySource;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellAddress;
+import org.apache.poi.util.TempFile;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.*;
 import org.junit.AfterClass;
@@ -25,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static com.github.pjfanning.xlsx.TestUtils.*;
 import static org.apache.poi.ss.usermodel.CellType.*;
@@ -503,6 +505,65 @@ public class StreamingWorkbookTest {
     } finally {
       ZipPackage.setUseTempFilePackageParts(false);
     }
+  }
+
+  @Test
+  public void testCloseReleasesSheetOpenedByIndex() throws IOException {
+    //sheets created by getSheetAt/getSheet are tracked separately from the ones created by the
+    //sheet iterator - Workbook.close() needs to close both of them
+    expectNoCommentsTempFilesLeftBehind(workbook -> workbook.getSheetAt(0));
+  }
+
+  @Test
+  public void testCloseReleasesSheetOpenedByName() throws IOException {
+    expectNoCommentsTempFilesLeftBehind(workbook -> workbook.getSheet("Sheet1"));
+  }
+
+  @Test
+  public void testCloseReleasesSheetOpenedByIterator() throws IOException {
+    expectNoCommentsTempFilesLeftBehind(workbook -> workbook.sheetIterator().next());
+  }
+
+  private void expectNoCommentsTempFilesLeftBehind(Function<Workbook, Sheet> sheetLookup)
+          throws IOException {
+    final File tempDir = getPoiTempDir();
+    final Set<String> before = listCommentsTempFiles(tempDir);
+    try(Workbook workbook = StreamingReader.builder()
+            .setReadComments(true)
+            .setCommentsImplementationType(CommentsImplementationType.TEMP_FILE_BACKED)
+            .open(new File("src/test/resources/commentTest.xlsx"))) {
+      for(Row row : sheetLookup.apply(workbook)) {
+        row.getRowNum();
+      }
+    }
+    final Set<String> after = listCommentsTempFiles(tempDir);
+    after.removeAll(before);
+    assertEquals("comments temp files should be deleted when the workbook is closed",
+            Collections.<String>emptySet(), after);
+  }
+
+  private static File getPoiTempDir() throws IOException {
+    final File probe = TempFile.createTempFile("probe", ".tmp");
+    try {
+      return probe.getParentFile();
+    } finally {
+      if(!probe.delete()) {
+        probe.deleteOnExit();
+      }
+    }
+  }
+
+  private static Set<String> listCommentsTempFiles(File dir) {
+    final String[] names = dir.list();
+    final Set<String> commentsFiles = new HashSet<>();
+    if(names != null) {
+      for(String name : names) {
+        if(name.startsWith("poi-comments")) {
+          commentsFiles.add(name);
+        }
+      }
+    }
+    return commentsFiles;
   }
 
   @Test


### PR DESCRIPTION
`StreamingWorkbookReader.close()` only walked the `sheets` list, which is populated exclusively by `getSheets()` (i.e. by `iterator()`/`spliterator()`). Sheets created through `getSheetAt(int)`/`getSheet(String)` are held in `sheetMap` instead, and were never closed — so their `StreamingSheetReader` never released its open `XMLEventReader`s or its comments table.

### Reproduction

With temp-file-backed comments, the comments temp file is left on disk for the life of the JVM:

```
sheetIterator() -> created=1 tmpfile, leftover-after-close=0
getSheetAt(0)   -> created=1 tmpfile, leftover-after-close=1  [poi-comments8037560696169532384.tmp]
```

`getSheetAt(0)` is the most common way to reach a sheet, so this affects most usages.

### Fix

`close()` now closes the sheets from both collections. They are collected into a `LinkedHashSet` first because `loadSheets()` can move `sheetMap` entries into `sheets`; `StreamingSheet` does not override `equals`/`hashCode`, so this dedupes on identity.

### Tests

Three tests in `StreamingWorkbookTest` assert no `poi-comments*` temp file survives `close()`, one per way of reaching a sheet. `testCloseReleasesSheetOpenedByIndex` and `testCloseReleasesSheetOpenedByName` fail without the fix; `testCloseReleasesSheetOpenedByIterator` passes either way and is there as a control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
