### PR TITLE
Fix two off-by-one bounds checks

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheet.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheet.java
@@ -167,7 +167,7 @@ public class StreamingSheet implements Sheet {
   @Override
   public CellRangeAddress getMergedRegion(int index) throws NoSuchElementException {
     List<CellRangeAddress> regions = getMergedRegions();
-    if(index > regions.size()) {
+    if(index < 0 || index >= regions.size()) {
       throw new NoSuchElementException("index " + index + " is out of range");
     }
     return regions.get(index);

--- a/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/OoxmlReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/OoxmlReader.java
@@ -242,7 +242,7 @@ public class OoxmlReader extends XSSFReader {
     }
 
     SheetData getSheetData(final int idx) throws MissingSheetException {
-      if (idx > sheetRefList.size()) {
+      if (idx < 0 || idx >= sheetRefList.size()) {
         throw new MissingSheetException("Failed to find sheet with id " + idx);
       }
       XSSFSheetRef matchedSheetRef = sheetRefList.get(idx);

--- a/src/test/java/com/github/pjfanning/xlsx/StreamingSheetTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/StreamingSheetTest.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.NoSuchElementException;
 
 import static com.github.pjfanning.xlsx.TestUtils.getInputStream;
 import static com.github.pjfanning.xlsx.TestUtils.nextRow;
@@ -131,6 +132,42 @@ public class StreamingSheetTest {
         assertEquals(1, sheet.getMergedRegions().size());
         assertEquals(1, sheet.getNumMergedRegions());
       }
+    }
+  }
+
+  @Test
+  public void testMergedRegionIndexOutOfRange() throws IOException {
+    try (UnsynchronizedByteArrayOutputStream bos = UnsynchronizedByteArrayOutputStream.builder().get()) {
+      try (XSSFWorkbook wb = new XSSFWorkbook()) {
+        XSSFSheet sheet = wb.createSheet();
+        assertEquals(0, sheet.addMergedRegion(new CellRangeAddress(1, 1, 1, 2)));
+        wb.write(bos);
+      }
+      try (Workbook workbook = StreamingReader.builder().open(bos.toInputStream())) {
+        Sheet sheet = workbook.getSheetAt(0);
+        for (Row row : sheet) {
+          //need to iterate over all rows before merged region data is read (it is at end of sheet data)
+        }
+        assertEquals(1, sheet.getNumMergedRegions());
+        assertNotNull(sheet.getMergedRegion(0));
+        //index == size used to raise IndexOutOfBoundsException instead
+        assertThrows(NoSuchElementException.class, () -> sheet.getMergedRegion(1));
+        assertThrows(NoSuchElementException.class, () -> sheet.getMergedRegion(-1));
+      }
+    }
+  }
+
+  @Test
+  public void testSheetIndexEqualToSheetCount() throws Exception {
+    try(
+            InputStream is = getInputStream("empty_sheet.xlsx");
+            Workbook workbook = StreamingReader.builder().open(is)
+    ) {
+      int numberOfSheets = workbook.getNumberOfSheets();
+      assertEquals(1, numberOfSheets);
+      //index == number of sheets used to raise IndexOutOfBoundsException instead
+      assertThrows(MissingSheetException.class, () -> workbook.getSheetAt(numberOfSheets));
+      assertThrows(MissingSheetException.class, () -> workbook.getSheetAt(-1));
     }
   }
 


### PR DESCRIPTION
Both guards used `>` where `>=` was meant, so the exact boundary index fell through to a `List.get()` and raised `IndexOutOfBoundsException` instead of the documented exception. Negative indexes were not rejected at all.

**`StreamingSheet.getMergedRegion`** (`StreamingSheet.java:170`) is documented to throw `NoSuchElementException`:

```
getMergedRegion(numMergedRegions)
-> java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
```

**`OoxmlReader.OoxmlSheetReader.getSheetData`** (`OoxmlReader.java:245`) backs `Workbook.getSheetAt` and is meant to throw `MissingSheetException`:

```
getSheetAt(numberOfSheets)
-> java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
```

The existing `testMissingSheetIndex` passes `getSheetAt(1000)`, which is far enough past the end to hit the old check, so the boundary case was untested.

### Tests

`testMergedRegionIndexOutOfRange` and `testSheetIndexEqualToSheetCount` in `StreamingSheetTest` cover `index == size` and `index == -1` for both methods. Both fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)