### PR TITLE
Do not share StAX factories between threads

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheetReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheetReader.java
@@ -43,8 +43,6 @@ import static com.github.pjfanning.xlsx.impl.NumberUtil.parseInt;
 public class StreamingSheetReader implements Iterable<Row> {
   private static final Logger LOG = LoggerFactory.getLogger(StreamingSheetReader.class);
 
-  private static XMLInputFactory xmlInputFactory;
-
   private final StreamingWorkbookReader streamingWorkbookReader;
   private final PackagePart packagePart;
   private final SharedStrings sst;
@@ -266,7 +264,7 @@ public class StreamingSheetReader implements Iterable<Row> {
     try {
       //StreamingRowIterator requires a new XMLEventReader with a new InputStream to be provided to start from the
       //beginning of the Sheet
-      XMLEventReader parser = getXmlInputFactory().createXMLEventReader(packagePart.getInputStream());
+      XMLEventReader parser = createXmlInputFactory().createXMLEventReader(packagePart.getInputStream());
       StreamingRowIterator iterator = new StreamingRowIterator(this,
               sst, stylesTable, parser, use1904Dates, rowCacheSize, hiddenColumns, columnWidths, mergedCells, hyperlinks,
               sharedFormulaMap, defaultRowHeight, sheet);
@@ -369,15 +367,18 @@ public class StreamingSheetReader implements Iterable<Row> {
     }
   }
 
-  private static XMLInputFactory getXmlInputFactory() {
-    if (xmlInputFactory == null) {
-      try {
-        xmlInputFactory = XMLHelper.newXMLInputFactory();
-      } catch (Exception e) {
-        LOG.error("Issue creating XMLInputFactory", e);
-        throw e;
-      }
+  /**
+   * A new factory is created for each reader rather than caching one in a static field.
+   * XMLInputFactory implementations are not thread-safe: the JDK implementation writes to its own
+   * fTempReader and fPropertyChanged fields on every createXMLEventReader call. Sheets belonging to
+   * the same workbook can be iterated concurrently, so a shared factory is a data race.
+   */
+  private static XMLInputFactory createXmlInputFactory() {
+    try {
+      return XMLHelper.newXMLInputFactory();
+    } catch (Exception e) {
+      LOG.error("Issue creating XMLInputFactory", e);
+      throw e;
     }
-    return xmlInputFactory;
   }
 }

--- a/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/OoXmlStrictConverter.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/OoXmlStrictConverter.java
@@ -19,14 +19,12 @@ public class OoXmlStrictConverter implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(OoXmlStrictConverter.class);
     private static final QName CONFORMANCE = new QName("conformance");
     private static final Properties mappings;
-    private static XMLEventFactory XEF;
-    private static XMLInputFactory XIF;
-    private static XMLOutputFactory XOF;
 
     static {
         mappings = OoXmlStrictConverterUtils.readMappings();
     }
 
+    private final XMLEventFactory xef;
     private final XMLEventWriter xew;
     private final XMLEventReader xer;
     private int depth = 0;
@@ -34,8 +32,9 @@ public class OoXmlStrictConverter implements AutoCloseable {
     private boolean inDateValue;
 
     public OoXmlStrictConverter(InputStream is, OutputStream os) throws XMLStreamException {
-        this.xer = getXmlInputFactory().createXMLEventReader(is);
-        this.xew = getXmlOutputFactory().createXMLEventWriter(os);
+        this.xer = newXmlInputFactory().createXMLEventReader(is);
+        this.xew = newXmlOutputFactory().createXMLEventWriter(os);
+        this.xef = newXmlEventFactory();
     }
 
     public boolean convertNextElement() throws XMLStreamException {
@@ -73,7 +72,7 @@ public class OoXmlStrictConverter implements AutoCloseable {
 
         double excelDate = DateUtil.getExcelDate(date);
 
-        return getXmlEventFactory().createCharacters(Double.toString(excelDate));
+        return xef.createCharacters(Double.toString(excelDate));
     }
 
     private EndElement updateDateFlagsOnEndElement(EndElement endElement) {
@@ -110,7 +109,7 @@ public class OoXmlStrictConverter implements AutoCloseable {
         this.inDateCell = true;
 
         // Change to numeric cell.
-        return getXmlEventFactory().createStartElement(startElement.getName(),
+        return xef.createStartElement(startElement.getName(),
                 changeTypeAttributeToNumeric(startElement.getAttributes()),
                 startElement.getNamespaces());
 
@@ -127,7 +126,7 @@ public class OoXmlStrictConverter implements AutoCloseable {
                 continue;
             }
 
-            result.add(getXmlEventFactory().createAttribute(attribute.getName(), "n"));
+            result.add(xef.createAttribute(attribute.getName(), "n"));
         }
 
         return Collections.unmodifiableList(result).iterator();
@@ -157,14 +156,14 @@ public class OoXmlStrictConverter implements AutoCloseable {
         xew.close();
     }
 
-    private static StartElement convertStartElement(StartElement startElement, boolean root) {
-        return getXmlEventFactory().createStartElement(updateQName(startElement.getName()),
+    private StartElement convertStartElement(StartElement startElement, boolean root) {
+        return xef.createStartElement(updateQName(startElement.getName()),
                 processAttributes(startElement.getAttributes(), startElement.getName().getNamespaceURI(), root),
                 processNamespaces(startElement.getNamespaces()));
     }
 
-    private static EndElement convertEndElement(EndElement endElement) {
-        return getXmlEventFactory().createEndElement(updateQName(endElement.getName()),
+    private EndElement convertEndElement(EndElement endElement) {
+        return xef.createEndElement(updateQName(endElement.getName()),
                 processNamespaces(endElement.getNamespaces()));
 
     }
@@ -181,7 +180,7 @@ public class OoXmlStrictConverter implements AutoCloseable {
         return qn;
     }
 
-    private static Iterator<Attribute> processAttributes(final Iterator<Attribute> iter,
+    private Iterator<Attribute> processAttributes(final Iterator<Attribute> iter,
             final String elementNamespaceUri, final boolean rootElement) {
         ArrayList<Attribute> list = new ArrayList<>();
         while(iter.hasNext()) {
@@ -197,7 +196,7 @@ public class OoXmlStrictConverter implements AutoCloseable {
                         break;
                     }
                 }
-                list.add(getXmlEventFactory().createAttribute(qn, newValue));
+                list.add(xef.createAttribute(qn, newValue));
             }
         }
         return Collections.unmodifiableList(list).iterator();
@@ -214,39 +213,36 @@ public class OoXmlStrictConverter implements AutoCloseable {
         return Collections.unmodifiableList(list).iterator();
     }
 
-    private static XMLInputFactory getXmlInputFactory() {
-        if (XIF == null) {
-            try {
-                XIF = XMLHelper.newXMLInputFactory();
-            } catch (Exception e) {
-                LOGGER.error("Issue creating XMLInputFactory", e);
-                throw e;
-            }
+    /**
+     * The StAX factories are created per converter instead of being cached in static fields.
+     * None of them are thread-safe (the JDK XMLInputFactory writes to its own fTempReader and
+     * fPropertyChanged fields on every createXMLEventReader call, and XMLEventFactory carries a
+     * mutable Location), and converters can be run concurrently.
+     */
+    private static XMLInputFactory newXmlInputFactory() {
+        try {
+            return XMLHelper.newXMLInputFactory();
+        } catch (Exception e) {
+            LOGGER.error("Issue creating XMLInputFactory", e);
+            throw e;
         }
-        return XIF;
     }
 
-    private static XMLOutputFactory getXmlOutputFactory() {
-        if (XOF == null) {
-            try {
-                XOF = XMLHelper.newXMLOutputFactory();
-            } catch (Exception e) {
-                LOGGER.error("Issue creating XMLOutputFactory", e);
-                throw e;
-            }
+    private static XMLOutputFactory newXmlOutputFactory() {
+        try {
+            return XMLHelper.newXMLOutputFactory();
+        } catch (Exception e) {
+            LOGGER.error("Issue creating XMLOutputFactory", e);
+            throw e;
         }
-        return XOF;
     }
 
-    private static XMLEventFactory getXmlEventFactory() {
-        if (XEF == null) {
-            try {
-                XEF = XMLHelper.newXMLEventFactory();
-            } catch (Exception e) {
-                LOGGER.error("Issue creating XMLEventFactory", e);
-                throw e;
-            }
+    private static XMLEventFactory newXmlEventFactory() {
+        try {
+            return XMLHelper.newXMLEventFactory();
+        } catch (Exception e) {
+            LOGGER.error("Issue creating XMLEventFactory", e);
+            throw e;
         }
-        return XEF;
     }
 }

--- a/src/test/java/com/github/pjfanning/xlsx/StreamingWorkbookTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/StreamingWorkbookTest.java
@@ -567,6 +567,44 @@ public class StreamingWorkbookTest {
   }
 
   @Test
+  public void testConcurrentSheetIteration() throws Exception {
+    //each StreamingRowIterator needs its own XMLInputFactory - a shared one is a data race
+    //because XMLInputFactory implementations mutate instance state on createXMLEventReader
+    final int threads = 8;
+    final int iterationsPerThread = 20;
+    final ExecutorService executorService = Executors.newFixedThreadPool(threads);
+    try {
+      final List<CompletableFuture<Integer>> futures = new ArrayList<>();
+      for(int t = 0; t < threads; t++) {
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        futures.add(future);
+        executorService.submit(() -> {
+          try {
+            int rowCount = 0;
+            for(int i = 0; i < iterationsPerThread; i++) {
+              try(Workbook workbook = openWorkbook("gaps.xlsx")) {
+                for(Row row : workbook.getSheetAt(0)) {
+                  assertNotNull(row);
+                  rowCount++;
+                }
+              }
+            }
+            future.complete(rowCount);
+          } catch (Throwable e) {
+            future.completeExceptionally(e);
+          }
+        });
+      }
+      for(CompletableFuture<Integer> future : futures) {
+        assertEquals(Integer.valueOf(3 * iterationsPerThread), future.get(2, TimeUnit.MINUTES));
+      }
+    } finally {
+      executorService.shutdown();
+      assertTrue(executorService.awaitTermination(1, TimeUnit.MINUTES));
+    }
+  }
+
+  @Test
   public void testCallingSheetIteratorTwice() throws IOException {
     try(Workbook workbook = openWorkbook("formats.xlsx")) {
       Iterator<Sheet> iter1 = workbook.sheetIterator();


### PR DESCRIPTION
`StreamingSheetReader` cached a single `XMLInputFactory` in a static field, lazily initialised with no synchronisation, and handed it to every `StreamingRowIterator` (`StreamingSheetReader.java:375`). `OoXmlStrictConverter` did the same for its `XMLInputFactory`, `XMLOutputFactory` and `XMLEventFactory`.

That is a data race on two counts. The lazy init itself is unsafe publication, and the factory is then *used* concurrently — sheets from one workbook can be iterated from different threads, which the existing two-sheet concurrency test in `StreamingWorkbookTest` already does.

### This is not just a theoretical spec concern

`XMLInputFactory` is not specified to be thread-safe, and the JDK implementation really does mutate itself on each use. Decompiling `com.sun.xml.internal.stream.XMLInputFactoryImpl.getXMLStreamReaderImpl` shows unconditional `putfield` writes to `fTempReader` and `fPropertyChanged` on every `createXMLEventReader` call:

```
  33: putfield      #18   // Field fTempReader:...XMLStreamReaderImpl;
  78: putfield      #22   // Field fPropertyChanged:Z
 112: putfield      #18   // Field fTempReader:...XMLStreamReaderImpl;
```

`XMLEventFactory` carries a mutable `Location` for the same reason.

### Fix

The factories are now created per use — one per `StreamingRowIterator`, one set per `OoXmlStrictConverter`. This matches POI, whose `XMLHelper` factory methods return a fresh instance to each caller. The cost is one factory per *sheet iterator*, not per row or cell, which is negligible next to parsing the sheet.

The event-building helpers in `OoXmlStrictConverter` become instance methods so they can use the per-converter `XMLEventFactory`.

### Tests

`testConcurrentSheetIteration` runs 8 threads × 20 open-and-iterate cycles and checks every row is seen. A race like this cannot be made to fail deterministically, so this test can produce a false pass but never a false failure — with per-use factories it is unconditionally correct. The full suite passes, including the OOXML-strict tests that exercise the refactored converter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)