### PR TITLE
Strip only the brackets when resolving a book index

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/BaseEvaluationWorkbook.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/BaseEvaluationWorkbook.java
@@ -76,7 +76,7 @@ abstract class BaseEvaluationWorkbook implements FormulaRenderingWorkbook, Evalu
   private int resolveBookIndex(String bookName) throws ReadException {
     // Strip the [] wrapper, if still present
     if (bookName.startsWith("[") && bookName.endsWith("]")) {
-      bookName = bookName.substring(1, bookName.length()-2);
+      bookName = bookName.substring(1, bookName.length()-1);
     }
 
     // Is it already in numeric form?

--- a/src/test/java/com/github/pjfanning/xlsx/impl/BaseEvaluationWorkbookTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/impl/BaseEvaluationWorkbookTest.java
@@ -1,0 +1,38 @@
+package com.github.pjfanning.xlsx.impl;
+
+import com.github.pjfanning.xlsx.StreamingReader;
+import org.apache.poi.ss.formula.SheetIdentifier;
+import org.apache.poi.ss.formula.ptg.NameXPxg;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class BaseEvaluationWorkbookTest {
+
+  @Test
+  public void testResolveBracketedBookIndex() throws Exception {
+    //the [] wrapper is stripped before the index is parsed
+    assertEquals(1, resolveBookIndex("[1]"));
+    assertEquals(23, resolveBookIndex("[23]"));
+  }
+
+  @Test
+  public void testResolveUnbracketedBookIndex() throws Exception {
+    assertEquals(1, resolveBookIndex("1"));
+  }
+
+  private int resolveBookIndex(final String bookName) throws Exception {
+    try (Workbook wb = StreamingReader.builder().open(new File("src/test/resources/gaps.xlsx"))) {
+      CurrentRowEvaluationWorkbook evaluationWorkbook = new CurrentRowEvaluationWorkbook(wb, null);
+      //a SheetIdentifier with no sheet part resolves to a workbook + named range reference
+      NameXPxg ptg = (NameXPxg) evaluationWorkbook.getNameXPtg(
+              "myNamedRange", new SheetIdentifier(bookName, null));
+      assertNotNull(ptg);
+      return ptg.getExternalWorkbookNumber();
+    }
+  }
+}


### PR DESCRIPTION
`resolveBookIndex` removes the `[]` wrapper before parsing the index, but takes one character too many (`BaseEvaluationWorkbook.java:79`):

```java
if (bookName.startsWith("[") && bookName.endsWith("]")) {
  bookName = bookName.substring(1, bookName.length()-2);
}
```

For `"[1]"` that yields `""` rather than `"1"`, so `parseInt` throws and every bracketed external book reference ends as:

```
ReadException: Book not linked for filename [1]
```

### Why it matters

This is on the shared-formula path. When a shared formula references another workbook, the `ReadException` is swallowed by the `catch (Exception e)` in `StreamingRowIterator`, the shifted formula is never set, and the cell then fails on `getCellFormula()` with *"This cell has a shared formula and it seems setReadSharedFormulas has been set to false or the formula can't be evaluated"* — which points at the wrong cause.

### Note on POI parity

This class is a cut-down copy of POI's `BaseXSSFEvaluationWorkbook`, and **POI has the same off-by-one**. Decompiling POI 5.5.1 shows `iconst_1` / `iconst_2` / `isub` around the `substring` call:

```
      19: iconst_1
      24: iconst_2
      25: isub
      26: invokevirtual  // Method java/lang/String.substring:(II)Ljava/lang/String;
```

So this is worth fixing upstream too — happy to drop the change here if you would rather keep strict parity with POI until that lands.

### Tests

New `BaseEvaluationWorkbookTest` resolves `"[1]"`, `"[23]"` and `"1"` through `getNameXPtg`. The bracketed cases fail without the fix; the unbracketed case passes either way and is there as a control. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)