### PR TITLE
Cache the parsed cell reference behind a hyperlink

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/XlsxHyperlink.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/XlsxHyperlink.java
@@ -21,6 +21,10 @@ public class XlsxHyperlink implements Hyperlink, Duplicatable {
   private final PackageRelationship _externalRel;
   private final HyperlinkData hyperlinkData; //contains a reference to the cell where the hyperlink is anchored, getRef()
   private String _address; //what the hyperlink refers to
+  //the ref is immutable, so the parsed form is cached - getFirstRow/getLastRow/getFirstColumn/
+  //getLastColumn are called for every hyperlink for every cell lookup on the sheet
+  private CellReference _firstCell;
+  private CellReference _lastCell;
 
   /**
    * Create a XlsxHyperlink and initialize it from the supplied HyperlinkData bean and package relationship
@@ -127,11 +131,22 @@ public class XlsxHyperlink implements Hyperlink, Duplicatable {
   }
 
   private CellReference buildFirstCellReference() {
-    return buildCellReference(false);
+    //parsed lazily so that a malformed ref still fails on access, as it did before caching
+    CellReference firstCell = _firstCell;
+    if (firstCell == null) {
+      firstCell = buildCellReference(false);
+      _firstCell = firstCell;
+    }
+    return firstCell;
   }
 
   private CellReference buildLastCellReference() {
-    return buildCellReference(true);
+    CellReference lastCell = _lastCell;
+    if (lastCell == null) {
+      lastCell = buildCellReference(true);
+      _lastCell = lastCell;
+    }
+    return lastCell;
   }
 
   private CellReference buildCellReference(boolean lastCell) {

--- a/src/test/java/com/github/pjfanning/xlsx/StreamingSheetTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/StreamingSheetTest.java
@@ -191,6 +191,37 @@ public class StreamingSheetTest {
     }
   }
 
+  // The parsed cell reference behind a hyperlink is cached, so repeated calls to the
+  // row/column getters must keep returning the same answer.
+  @Test
+  public void testHyperlinkBoundsAreStableAcrossCalls() throws Exception {
+    try(
+            InputStream is = getInputStream("59775.xlsx");
+            Workbook wb = StreamingReader.builder().setReadHyperlinks(true).open(is)
+    ) {
+      Sheet sheet = wb.getSheetAt(0);
+      for (Row row : sheet) {
+        //hyperlink data is at the end of the sheet, so it has to be fully read first
+      }
+      List<? extends Hyperlink> links = sheet.getHyperlinkList();
+      assertFalse(links.isEmpty());
+      for (Hyperlink link : links) {
+        int firstRow = link.getFirstRow();
+        int lastRow = link.getLastRow();
+        int firstColumn = link.getFirstColumn();
+        int lastColumn = link.getLastColumn();
+        for (int i = 0; i < 3; i++) {
+          assertEquals(firstRow, link.getFirstRow());
+          assertEquals(lastRow, link.getLastRow());
+          assertEquals(firstColumn, link.getFirstColumn());
+          assertEquals(lastColumn, link.getLastColumn());
+        }
+        assertTrue(lastRow >= firstRow);
+        assertTrue(lastColumn >= firstColumn);
+      }
+    }
+  }
+
   @Test
   public void testRowIteratorNext() throws Exception {
     try(


### PR DESCRIPTION
`XlsxHyperlink.getFirstRow`, `getLastRow`, `getFirstColumn` and `getLastColumn` each built a **new** `CellReference` (or `AreaReference`) from the ref string on every call (`XlsxHyperlink.java:137`).

`StreamingSheet.getHyperlink(CellAddress)` scans every hyperlink on the sheet and calls all four getters, and `StreamingCell.getHyperlink()` calls that per cell. So looking up hyperlinks while reading a sheet cost `cells × hyperlinks × 4` reference parses.

### Measured impact

A 24,000-cell sheet, calling `getHyperlink()` for every cell:

| hyperlinks on sheet | baseline | patched |
|---|---|---|
| 300 | min **3443ms** / median 3580ms | min **203ms** / median 310ms |
| 0 | min 297ms / median 312ms | min 236ms / median 276ms |

Roughly **17x faster** with 300 hyperlinks, and looking up hyperlinks on a sheet that has them now costs about the same as on a sheet that does not. This is only a 24k-cell sheet — the gap widens with sheet size, since the cost was quadratic in cells × hyperlinks.

### Fix

The ref is immutable, so the parsed form is memoised. Parsing stays **lazy** rather than moving into the constructor, so a malformed ref still fails on access exactly where it failed before — moving it to the constructor would turn a lazily-tolerated bad ref into a failure during `initHyperlinks()`.

### Tests

`testHyperlinkBoundsAreStableAcrossCalls` asserts the four getters keep returning the same values across repeated calls, which is what a broken cache would break. The existing hyperlink tests in `StreamingSheetTest` already cover the values themselves. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)