### PR TITLE
Make close() robust when a sheet or a workbook is only half set up

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheetReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingSheetReader.java
@@ -332,7 +332,24 @@ public class StreamingSheetReader implements Iterable<Row> {
 
   public void close() throws CloseException {
     try {
-      iterators.forEach(iter -> iter.close(false));
+      //every iterator is closed even if one of them fails, so that a single bad iterator
+      //cannot leak the rest. we avoid ConcurrentModificationException by passing
+      //removeFromReader=false
+      CloseException failure = null;
+      for (StreamingRowIterator iterator : iterators) {
+        try {
+          iterator.close(false);
+        } catch (CloseException e) {
+          if (failure == null) {
+            failure = e;
+          } else {
+            failure.addSuppressed(e);
+          }
+        }
+      }
+      if (failure != null) {
+        throw failure;
+      }
     } finally {
       // The sst instance is closed at the workbook level
       if (commentsTable instanceof AutoCloseable) {

--- a/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReader.java
@@ -355,8 +355,11 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, Date1904Support
       closeSheets();
     } finally {
       try {
-        pkg.revert();
-        pkg.close();
+        //pkg is null if init() was never called, or failed before the package was opened
+        if (pkg != null) {
+          pkg.revert();
+          pkg.close();
+        }
       } finally {
         if(tmp != null) {
           if (log.isDebugEnabled()) {

--- a/src/test/java/com/github/pjfanning/xlsx/impl/StreamingSheetReaderTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/impl/StreamingSheetReaderTest.java
@@ -1,5 +1,6 @@
 package com.github.pjfanning.xlsx.impl;
 
+import com.github.pjfanning.xlsx.exceptions.CloseException;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.DateUtil;
@@ -9,7 +10,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.FileInputStream;
+import java.lang.reflect.Field;
 import java.time.LocalDate;
+import java.util.List;
 
 public class StreamingSheetReaderTest {
   @Test
@@ -35,5 +38,31 @@ public class StreamingSheetReaderTest {
     } finally {
       reader.close();
     }
+  }
+
+  @Test
+  public void testCloseClosesEveryIteratorEvenIfOneFails() throws Exception {
+    PackagePart packagePart = Mockito.mock(PackagePart.class);
+    Mockito.when(packagePart.getInputStream()).thenAnswer(I ->
+            new FileInputStream("src/test/resources/strict.dates.xml"));
+    StreamingSheetReader reader = new StreamingSheetReader(
+            null, packagePart, null, null, null, true, 100);
+
+    StreamingRowIterator failing = Mockito.mock(StreamingRowIterator.class);
+    Mockito.doThrow(new CloseException("boom")).when(failing).close(false);
+    StreamingRowIterator healthy = Mockito.mock(StreamingRowIterator.class);
+
+    Field iteratorsField = StreamingSheetReader.class.getDeclaredField("iterators");
+    iteratorsField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<StreamingRowIterator> iterators = (List<StreamingRowIterator>) iteratorsField.get(reader);
+    iterators.clear();
+    iterators.add(failing);
+    iterators.add(healthy);
+
+    //the failure is still reported...
+    Assert.assertThrows(CloseException.class, reader::close);
+    //...but the iterator after it was closed anyway, rather than being leaked
+    Mockito.verify(healthy).close(false);
   }
 }

--- a/src/test/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReaderTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/impl/StreamingWorkbookReaderTest.java
@@ -1,0 +1,19 @@
+package com.github.pjfanning.xlsx.impl;
+
+import com.github.pjfanning.xlsx.StreamingReader;
+import org.junit.Test;
+
+public class StreamingWorkbookReaderTest {
+
+  /**
+   * close() used to throw NullPointerException if the reader was never successfully initialised,
+   * because the OPCPackage field was still null.
+   */
+  @Test
+  public void testCloseBeforeInit() throws Exception {
+    StreamingWorkbookReader reader = new StreamingWorkbookReader(StreamingReader.builder());
+    reader.close();
+    //closing twice should also be safe
+    reader.close();
+  }
+}


### PR DESCRIPTION
The two items from the Minor list that were worth acting on. Both are on `close()` paths.

### 1. One bad iterator no longer leaks the rest

`StreamingSheetReader.close()` used `iterators.forEach(iter -> iter.close(false))`, so the first `CloseException` abandoned every remaining iterator and leaked its open `XMLEventReader`.

Each iterator is now closed in turn. The first failure is kept, later ones are attached as suppressed, and it is rethrown once they have all been closed — so the error is still reported, but not at the cost of the other iterators.

### 2. `close()` before a successful `init()` no longer throws NPE

`StreamingWorkbookReader.close()` called `pkg.revert()` unguarded, which throws `NullPointerException` if `init` was never called, or failed before the package was opened. The package is now null-checked.

### What I deliberately did not change

Three things from that list I think should stay as they are:

- **`pkg.revert()` followed by `pkg.close()`.** `OPCPackage.close()` does start with an `isClosed()` early return, so the second call looks redundant — but `isClosed()` is *abstract* on `OPCPackage` and implemented per subclass, so I could not demonstrate it is a no-op for every package type. It costs nothing to keep, and removing it on an unverified assumption could leak. My original "redundant" call was too confident.
- **`getMergedRegions()` / `getHyperlinkList()` not forcing a parse.** Making them parse on demand would mean reading the *entire* sheet (both live at the end of the sheet XML), which is exactly what a streaming reader should not do behind the caller's back. Both already carry javadoc saying they only work after the sheet is fully read, so there is nothing to fix here — I overstated this one.
- **`StreamingWorkbook.getNames(String)` throwing `UnsupportedOperationException`.** I suggested returning an empty list. That would be worse: it asserts "this workbook has no named ranges" when the truth is that this reader never looked. Throwing is the honest answer. The formula path logs a warning either way, so nothing is actually gained.

### Tests

- `testCloseClosesEveryIteratorEvenIfOneFails` injects a failing and a healthy iterator, asserts the `CloseException` still surfaces, and verifies the healthy one was closed regardless.
- `testCloseBeforeInit` closes a never-initialised reader, twice.

Both fail without the fixes. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)