### PR TITLE
Make strict OOXML conversion roughly 190x faster

### DIFF
--- a/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/OoXmlStrictConverter.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/OoXmlStrictConverter.java
@@ -19,9 +19,17 @@ public class OoXmlStrictConverter implements AutoCloseable {
     private static final Logger LOGGER = LoggerFactory.getLogger(OoXmlStrictConverter.class);
     private static final QName CONFORMANCE = new QName("conformance");
     private static final Properties mappings;
+    //stringPropertyNames() builds a fresh HashSet on every call, and this is consulted once per
+    //attribute, so the prefix mappings are materialised once here instead
+    private static final Map<String, String> prefixMappings;
 
     static {
         mappings = OoXmlStrictConverterUtils.readMappings();
+        final Map<String, String> prefixes = new LinkedHashMap<>();
+        for (String key : mappings.stringPropertyNames()) {
+            prefixes.put(key, mappings.getProperty(key));
+        }
+        prefixMappings = Collections.unmodifiableMap(prefixes);
     }
 
     private final XMLEventFactory xef;
@@ -57,8 +65,6 @@ public class OoXmlStrictConverter implements AutoCloseable {
                 xew.add(xe);
             }
         }
-
-        xew.flush();
 
         return true;
     }
@@ -152,8 +158,18 @@ public class OoXmlStrictConverter implements AutoCloseable {
 
     @Override
     public void close() throws XMLStreamException {
-        xer.close();
-        xew.close();
+        //the writer is flushed here rather than after every single element. All callers use
+        //try-with-resources with the converter declared last, so this runs before the
+        //underlying OutputStream is closed.
+        try {
+            xew.flush();
+        } finally {
+            try {
+                xer.close();
+            } finally {
+                xew.close();
+            }
+        }
     }
 
     private StartElement convertStartElement(StartElement startElement, boolean root) {
@@ -190,9 +206,9 @@ public class OoXmlStrictConverter implements AutoCloseable {
                 //drop attribute
             } else {
                 String newValue = att.getValue();
-                for(String key : mappings.stringPropertyNames()) {
-                    if(att.getValue().startsWith(key)) {
-                        newValue = att.getValue().replace(key, mappings.getProperty(key));
+                for(Map.Entry<String, String> mapping : prefixMappings.entrySet()) {
+                    if(att.getValue().startsWith(mapping.getKey())) {
+                        newValue = att.getValue().replace(mapping.getKey(), mapping.getValue());
                         break;
                     }
                 }
@@ -202,11 +218,20 @@ public class OoXmlStrictConverter implements AutoCloseable {
         return Collections.unmodifiableList(list).iterator();
     }
 
-    private static Iterator<Namespace> processNamespaces(final Iterator<Namespace> iter) {
+    private Iterator<Namespace> processNamespaces(final Iterator<Namespace> iter) {
         ArrayList<Namespace> list = new ArrayList<>();
         while(iter.hasNext()) {
             Namespace ns = iter.next();
-            if(!ns.isDefaultNamespaceDeclaration() && !mappings.containsKey(ns.getNamespaceURI())) {
+            final String mappedUri = prefixMappings.get(ns.getNamespaceURI());
+            if(mappedUri != null) {
+                //rewrite the declaration to the mapped namespace rather than dropping it. If it is
+                //dropped, the writer is left with elements in a namespace nothing declares, and
+                //POI's XMLOutputFactory has isRepairingNamespaces set, so it has to synthesise a
+                //declaration for every single element.
+                list.add(ns.isDefaultNamespaceDeclaration()
+                        ? xef.createNamespace(mappedUri)
+                        : xef.createNamespace(ns.getPrefix(), mappedUri));
+            } else if(!ns.isDefaultNamespaceDeclaration()) {
                 list.add(ns);
             }
         }

--- a/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/TempFileDataStore.java
+++ b/src/main/java/com/github/pjfanning/xlsx/impl/ooxml/TempFileDataStore.java
@@ -9,6 +9,7 @@ import java.io.*;
 class TempFileDataStore implements TempDataStore {
 
   private static final Logger log = LoggerFactory.getLogger(TempFileDataStore.class);
+  private static final int BUFFER_SIZE = 8192;
   private File tempFile;
 
   @Override
@@ -17,7 +18,7 @@ class TempFileDataStore implements TempDataStore {
       throw new IOException("temp file already created");
     }
     tempFile = TempFile.createTempFile("excel-streaming-reader", ".xml");
-    return new FileOutputStream(tempFile);
+    return new BufferedOutputStream(new FileOutputStream(tempFile), BUFFER_SIZE);
   }
 
   @Override
@@ -25,7 +26,7 @@ class TempFileDataStore implements TempDataStore {
     if (tempFile == null) {
       throw new IOException("temp file was never populated");
     }
-    return new FileInputStream(tempFile);
+    return new BufferedInputStream(new FileInputStream(tempFile), BUFFER_SIZE);
   }
 
   @Override

--- a/src/test/java/com/github/pjfanning/xlsx/impl/ooxml/TempDataStoreTest.java
+++ b/src/test/java/com/github/pjfanning/xlsx/impl/ooxml/TempDataStoreTest.java
@@ -1,0 +1,51 @@
+package com.github.pjfanning.xlsx.impl.ooxml;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class TempDataStoreTest {
+
+  /**
+   * The output stream is buffered, so anything still sitting in the buffer has to reach the file
+   * before getInputStream() is called. A payload smaller than the buffer would be lost entirely
+   * if that ever stopped being true.
+   */
+  @Test
+  public void testTempFileDataStoreRoundTrip() throws Exception {
+    assertRoundTrip(new TempFileDataStore(), 64);
+    assertRoundTrip(new TempFileDataStore(), 8192 * 3 + 17);
+  }
+
+  @Test
+  public void testTempMemoryDataStoreRoundTrip() throws Exception {
+    assertRoundTrip(new TempMemoryDataStore(), 64);
+    assertRoundTrip(new TempMemoryDataStore(), 8192 * 3 + 17);
+  }
+
+  private void assertRoundTrip(TempDataStore store, int size) throws Exception {
+    final byte[] payload = new byte[size];
+    new Random(size).nextBytes(payload);
+    try {
+      try (OutputStream os = store.getOutputStream()) {
+        os.write(payload);
+      }
+      try (InputStream is = store.getInputStream();
+           ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+        final byte[] buf = new byte[1024];
+        int read;
+        while ((read = is.read(buf)) != -1) {
+          bos.write(buf, 0, read);
+        }
+        assertArrayEquals(payload, bos.toByteArray());
+      }
+    } finally {
+      store.close();
+    }
+  }
+}


### PR DESCRIPTION
Reading a strict-format xlsx converts the styles, shared strings, themes and comments parts through `OoXmlStrictConverter` into a `TempDataStore`. That path was pathologically slow — roughly **26 seconds per megabyte**.

### Cause

`TempFileDataStore.getOutputStream()` handed the converter a raw `FileOutputStream`. The StAX event writer emits small fragments, so each became its own write syscall. A plain StAX event copy with *no conversion logic at all* shows the scale:

```
unbuffered FileOutputStream   21006 events   2710ms
BufferedOutputStream          21006 events     30ms
```

~90x, from buffering alone. The conversion logic was never the problem.

### Changes, in descending order of impact

1. **`TempFileDataStore` buffers its streams** (`BufferedOutputStream` out, `BufferedInputStream` in). This is nearly all of the win.
2. **Flush once on close** rather than after every element. All callers use try-with-resources with the converter declared last, so the flush still happens before the underlying stream is closed.
3. **`processNamespaces` rewrites a mapped namespace declaration** to the target namespace instead of dropping it. Dropped declarations left elements in a namespace nothing declared, and POI's `XMLHelper.newXMLOutputFactory()` sets `isRepairingNamespaces`, so the writer had to synthesise a declaration for every element. **Output is byte-identical either way** — I verified this by diffing the converted output before and after.
4. **Prefix mappings materialised once** instead of calling `Properties.stringPropertyNames()` — which builds a fresh `HashSet` — once per attribute.

### Measured impact

Through the real path (converter writing into a `TempFileDataStore`):

| input | baseline | patched | speedup |
|---|---|---|---|
| 172 KB | 2448 ms | 94 ms | **26x** |
| 3067 KB | 80535 ms | 425 ms | **189x** |

The baseline is superlinear from syscall pressure, so the bigger the part, the worse it was.

### Correction to what I said earlier

I previously reported these changes as having **no measurable effect**. That measurement was wrong: my benchmark wrote to a raw `FileOutputStream` of its own instead of going through `TempFileDataStore`, so it never exercised the one change that mattered. The conclusion I drew from it — that the namespace repairing was the dominant cost — was also wrong; repairing vs non-repairing is noise (2602ms vs 2941ms).

### Tests

New `TempDataStoreTest` round-trips payloads through both store implementations, at 64 bytes and at 3×buffer+17 bytes. The small payload is the important one: it sits entirely inside the buffer and would be lost if the output ever stopped being flushed before `getInputStream()`. Existing strict-format tests (`OoxmlStrictHelperTest`, the strict reads in `StreamingReaderTest`) cover output correctness. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)